### PR TITLE
SCAL-1212 indexes in mongo active record

### DIFF
--- a/lib/scalarm/database/core/mongo_active_record.rb
+++ b/lib/scalarm/database/core/mongo_active_record.rb
@@ -318,9 +318,6 @@ module Scalarm
       end
 
       # INITIALIZATION STUFF
-      def self.init(*args)
-
-      end
 
       ##
       # Backward-compatible alias for connection_init

--- a/lib/scalarm/database/core/mongo_active_record.rb
+++ b/lib/scalarm/database/core/mongo_active_record.rb
@@ -19,6 +19,11 @@ module Scalarm
       @options = {}
       @@client = nil
 
+      class << self
+        attr_accessor :_indexed_attributes
+      end
+      @_indexed_attributes = []
+
       def self.ids_auto_convert
         true
       end
@@ -313,6 +318,9 @@ module Scalarm
       end
 
       # INITIALIZATION STUFF
+      def self.init(*args)
+
+      end
 
       ##
       # Backward-compatible alias for connection_init

--- a/lib/scalarm/database/core/mongo_active_record_utils.rb
+++ b/lib/scalarm/database/core/mongo_active_record_utils.rb
@@ -41,11 +41,18 @@ module Scalarm
           end
         end
 
+        ##
+        # Mark the given attribute to be indexed. The actual index in mongodb will be created by calling build_indexes
+        # rake task in Scalarm experiment manager.
+        # @param [String or Hash] String-type value will create a single-key index
+        #   - Hash-type value will create a compound-index ()https://docs.mongodb.org/v3.0/core/index-compound/)
         def create_index(attribute)
           @_indexed_attributes << attribute
-          # puts "Create index: #{attribute} - #{@_indexed_attributes}"
         end
 
+        ##
+        # Callback to add _indexed_attributes instance variable to all classes inherited from MongoActiveRecord
+        # http://ruby-doc.org/core-2.2.0/Class.html#method-i-inherited
         def inherited(subclass)
           instance_var = "@_indexed_attributes"
           subclass.instance_variable_set(instance_var, [])

--- a/lib/scalarm/database/core/mongo_active_record_utils.rb
+++ b/lib/scalarm/database/core/mongo_active_record_utils.rb
@@ -41,6 +41,16 @@ module Scalarm
           end
         end
 
+        def create_index(attribute)
+          @_indexed_attributes << attribute
+          # puts "Create index: #{attribute} - #{@_indexed_attributes}"
+        end
+
+        def inherited(subclass)
+          instance_var = "@_indexed_attributes"
+          subclass.instance_variable_set(instance_var, [])
+        end
+
       end
     end
   end

--- a/lib/scalarm/database/model/cloud_image_secrets.rb
+++ b/lib/scalarm/database/model/cloud_image_secrets.rb
@@ -20,6 +20,6 @@ module Scalarm::Database::Model
     use_collection 'cloud_image_secrets'
     attr_join :user, ScalarmUser
 
-    create_index({user_id: 1, cloud_name:1})
+    create_index({user_id: 1, cloud_name: 1})
   end
 end

--- a/lib/scalarm/database/model/cloud_image_secrets.rb
+++ b/lib/scalarm/database/model/cloud_image_secrets.rb
@@ -19,5 +19,7 @@ module Scalarm::Database::Model
   class CloudImageSecrets < Scalarm::Database::EncryptedMongoActiveRecord
     use_collection 'cloud_image_secrets'
     attr_join :user, ScalarmUser
+
+    create_index({user_id: 1, cloud_name:1})
   end
 end

--- a/lib/scalarm/database/model/cloud_secrets.rb
+++ b/lib/scalarm/database/model/cloud_secrets.rb
@@ -15,5 +15,7 @@ module Scalarm::Database::Model
     class CloudSecrets < Scalarm::Database::EncryptedMongoActiveRecord
       use_collection 'cloud_secrets'
       attr_join :user, ScalarmUser
+
+      create_index({cloud_name: 1, user_id: 1})
     end
 end

--- a/lib/scalarm/database/model/cloud_vm_record.rb
+++ b/lib/scalarm/database/model/cloud_vm_record.rb
@@ -27,7 +27,7 @@ module Scalarm::Database::Model
     attr_join :image_secrets, CloudImageSecrets
 
     def cloud_secrets
-      @cloud_secrets ||= CloudSecrets.find_by_query(cloud_name: cloud_name.to_s, user_id: user_id.to_s)
+      @cloud_secrets ||= CloudSecrets.where(cloud_name: cloud_name.to_s, user_id: user_id.to_s).first
     end
 
     # additional info for specific cloud should be provided by CloudClient

--- a/lib/scalarm/database/model/experiment.rb
+++ b/lib/scalarm/database/model/experiment.rb
@@ -103,6 +103,8 @@ module Scalarm::Database::Model
     attr_join :user, ScalarmUser
 
     create_index 'user_id'
+    create_index 'simulation_id'
+    create_index 'is_running'
 
     ID_DELIM = '___'
 

--- a/lib/scalarm/database/model/experiment.rb
+++ b/lib/scalarm/database/model/experiment.rb
@@ -102,6 +102,8 @@ module Scalarm::Database::Model
     attr_join :simulation, Simulation
     attr_join :user, ScalarmUser
 
+    create_index 'user_id'
+
     ID_DELIM = '___'
 
     def simulation_runs

--- a/lib/scalarm/database/model/experiment.rb
+++ b/lib/scalarm/database/model/experiment.rb
@@ -105,6 +105,7 @@ module Scalarm::Database::Model
     create_index 'user_id'
     create_index 'simulation_id'
     create_index 'is_running'
+    create_index 'shared_with'
 
     ID_DELIM = '___'
 

--- a/lib/scalarm/database/model/experiment.rb
+++ b/lib/scalarm/database/model/experiment.rb
@@ -102,10 +102,10 @@ module Scalarm::Database::Model
     attr_join :simulation, Simulation
     attr_join :user, ScalarmUser
 
-    create_index 'user_id'
-    create_index 'simulation_id'
-    create_index 'is_running'
-    create_index 'shared_with'
+    create_index "user_id"
+    create_index "simulation_id"
+    create_index "is_running"
+    create_index "shared_with"
 
     ID_DELIM = '___'
 

--- a/lib/scalarm/database/model/grid_credentials.rb
+++ b/lib/scalarm/database/model/grid_credentials.rb
@@ -23,6 +23,8 @@ module Scalarm::Database::Model
     use_collection 'grid_credentials'
     attr_join :user, ScalarmUser
 
+    create_index "user_id"
+
     def password
       if hashed_password
         decipher = GridCredentials::decipher

--- a/lib/scalarm/database/model/mongo_lock_record.rb
+++ b/lib/scalarm/database/model/mongo_lock_record.rb
@@ -10,6 +10,9 @@ module Scalarm::Database::Model
   # global_pid::  _string_ globally uniqe identifier of thread that set the lock;
   #               format: <host_name_or_ip>_<pid>_<thread_id>
   class MongoLockRecord < Scalarm::Database::MongoActiveRecord
+
+    create_index "name"
+
     def self.collection_name
       'mongo_locks'
     end

--- a/lib/scalarm/database/model/pl_grid_job.rb
+++ b/lib/scalarm/database/model/pl_grid_job.rb
@@ -23,7 +23,7 @@ module Scalarm::Database::Model
     attr_join :experiment, Experiment
 
     def credentials
-      @credentials ||= GridCredentials.find_by_user_id(user_id)
+      @credentials ||= GridCredentials.where(user_id: user_id).first
     end
 
     def to_s

--- a/lib/scalarm/database/model/private_machine_credentials.rb
+++ b/lib/scalarm/database/model/private_machine_credentials.rb
@@ -19,6 +19,8 @@ module Scalarm::Database::Model
 
     attr_join :user, ScalarmUser
 
+    create_index({user_id: 1, host: 1})
+
     def machine_desc
       "#{login}@#{host}:#{port}"
     end

--- a/lib/scalarm/database/model/private_machine_record.rb
+++ b/lib/scalarm/database/model/private_machine_record.rb
@@ -15,6 +15,8 @@ module Scalarm::Database::Model
     # SimulationManagerRecord
     use_collection 'private_machine_records'
 
+    create_index({user_id: 1, experiment_id: 1, infrastructure: 1})
+
     attr_join :credentials, PrivateMachineCredentials
     attr_join :experiment, Experiment
   end

--- a/lib/scalarm/database/model/scalarm_user.rb
+++ b/lib/scalarm/database/model/scalarm_user.rb
@@ -11,6 +11,9 @@ module Scalarm::Database::Model
   class ScalarmUser < Scalarm::Database::MongoActiveRecord
     use_collection 'scalarm_users'
 
+    create_index "login"
+
+
     ##
     # A setter for a user password, it stores only password digest,
     # so original password cannot be restored.

--- a/lib/scalarm/database/model/simulation.rb
+++ b/lib/scalarm/database/model/simulation.rb
@@ -37,6 +37,8 @@ module Scalarm::Database::Model
     attr_join :output_reader, SimulationOutputReader
     attr_join :progress_monitor, SimulationProgressMonitor
 
+    create_index({user_id: 1, name: 1})
+
     def set_simulation_binaries(filename, binary_data)
       @attributes['simulation_binaries_id'] = @@grid  .put(binary_data, :filename => filename)
     end

--- a/lib/scalarm/database/model/simulation_manager_temp_password.rb
+++ b/lib/scalarm/database/model/simulation_manager_temp_password.rb
@@ -19,6 +19,10 @@ module Scalarm::Database::Model
     # TODO attr_join by const
     # attr_join :experiment, Experiment
 
+    create_index "experiment_id"
+    create_index "sm_uuid"
+    create_index "user_id"
+
     def self.create_new_password_for(sm_uuid, experiment_id)
       password = SecureRandom.base64
       temp_pass = self.new(sm_uuid: sm_uuid,

--- a/lib/scalarm/database/model/user_session.rb
+++ b/lib/scalarm/database/model/user_session.rb
@@ -13,5 +13,7 @@ module Scalarm::Database::Model
   # last_update:: timestamp of last authentication made with this session
   class UserSession < Scalarm::Database::MongoActiveRecord
     use_collection 'users_session'
+
+    create_index({session_id: 1, uuid: 1})
   end
 end

--- a/lib/scalarm/database/simulation_run_factory.rb
+++ b/lib/scalarm/database/simulation_run_factory.rb
@@ -50,32 +50,10 @@ module Scalarm::Database
     def create_table
       raise('No Simulation Run DB available') if collection.nil?
 
-      %w(index is_done to_sent).each do |index_sym|
-        # checking index_informations disabled due to "no collection" problem
-        # before initialization
-        #unless collection.index_information.include?(index_sym.to_s)
-        collection.create_index([[index_sym.to_s, Mongo::ASCENDING]])
-        #end
-      end
-
-      # FIXME error-causing code
-      # sharding collection
-      cmd = BSON::OrderedHash.new
-      cmd['enableSharding'] = collection.db.name
-      begin
-        MongoActiveRecord.execute_raw_command_on('admin', cmd)
-      rescue => e
-        Logger.error(e)
-      end
-
-      cmd = BSON::OrderedHash.new
-      cmd['shardcollection'] = "#{collection.db.name}.#{collection_name}"
-      cmd['key'] = {'index' => 1}
-      begin
-        MongoActiveRecord.execute_raw_command_on('admin', cmd)
-      rescue => e
-        Logger.error(e)
-      end
+      collection.create_index("index")
+      collection.create_index("sm_uuid")
+      collection.create_index("result")
+      collection.create_index({is_done: 1, to_sent: 1})
     end
   end
 


### PR DESCRIPTION
Support for single and multikey indexes and a lot of indexes in core classes.
